### PR TITLE
Fix Darwin Core field typo

### DIFF
--- a/backend/utils/mapper.py
+++ b/backend/utils/mapper.py
@@ -4,7 +4,8 @@ dwc_field_map = {
     "fullname": "scientificNameAuthorship",
     "cname": "vernacularName",
     "family": "family",
-    "family_cname": "familyVerncularName",
+    # Darwin Core uses "vernacular". Fix a long-standing typo here.
+    "family_cname": "familyVernacularName",
     "pt_name": "higherClassification",
     "source": "establishmentMeans",
     "iucn_category": "iucnStatus",

--- a/frontend/src/lib/dwcMapper.ts
+++ b/frontend/src/lib/dwcMapper.ts
@@ -8,7 +8,8 @@ export const dwcFieldMap: Record<string, string> = {
   fullname: "scientificNameAuthorship",
   cname: "vernacularName",
   family: "family",
-  family_cname: "familyVerncularName", // not standard, but retained
+  // Darwin Core uses "vernacular". Fix a long-standing typo here.
+  family_cname: "familyVernacularName",
   pt_name: "higherClassification",
   source: "establishmentMeans",
   iucn_category: "iucnStatus", // not standard, but used in export


### PR DESCRIPTION
## Summary
- fix `family_cname` mapping typo in backend utils
- fix same mapping typo in frontend TypeScript mapping

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `npm run check` *(fails: `svelte-kit` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684247ff624083269c5f82158aadcfea