### PR TITLE
Fix docs iframe and make API base URL configurable

### DIFF
--- a/frontend/src/routes/documentation/+page.svelte
+++ b/frontend/src/routes/documentation/+page.svelte
@@ -21,7 +21,7 @@
 <div class="border rounded shadow-md overflow-hidden">
   <iframe
     title="API docs"
-    src="http://localhost:8000/docs"
+    src="/docs"
     class="w-full h-[80vh] border-none"
   ></iframe>
 </div>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,22 +1,30 @@
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import path from 'path';
 
-export default defineConfig({
-  plugins: [sveltekit()],
-  resolve: {
-    alias: {
-      $lib: path.resolve(__dirname, 'src/lib'),
-      $stores: path.resolve(__dirname, 'src/stores')
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd());
+  const API_BASE_URL = env.VITE_API_BASE_URL || '/api';
+
+  return {
+    plugins: [sveltekit()],
+    resolve: {
+      alias: {
+        $lib: path.resolve(__dirname, 'src/lib'),
+        $stores: path.resolve(__dirname, 'src/stores')
+      }
+    },
+    optimizeDeps: {
+      include: ['flowbite', 'flowbite-svelte'],
+    },
+    server: {
+      proxy: API_BASE_URL.startsWith('http')
+        ? { '/api': API_BASE_URL }
+        : undefined
+    },
+    define: {
+      __API_BASE_URL__: JSON.stringify(API_BASE_URL)
     }
-  },
-  optimizeDeps: {
-    include: ['flowbite', 'flowbite-svelte'],
-  },
-  server: {
-    proxy: {
-      '/api': 'http://localhost:8000'
-    }
-  }
+  };
 });
 


### PR DESCRIPTION
## Summary
- use relative path for API docs iframe
- allow configuring API base URL in Vite config

## Testing
- `npm run check` *(fails: svelte-kit not found)*

------
https://chatgpt.com/codex/tasks/task_e_684250d34ee08326a3b208cd29a83c94