### PR TITLE
Remove backend virtualenv and add ignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Python virtual environments
+venv/
+*/venv/
+
+# Node dependencies
+frontend/node_modules/
+
+# SvelteKit build outputs
+frontend/.svelte-kit/
+frontend/build/

--- a/backend/venv/pyvenv.cfg
+++ b/backend/venv/pyvenv.cfg
@@ -1,3 +1,0 @@
-home = /Library/Developer/CommandLineTools/usr/bin
-include-system-site-packages = false
-version = 3.9.6


### PR DESCRIPTION
## Summary
- stop tracking the `backend/venv` directory
- add repository `.gitignore` rules for Python venvs, `frontend/node_modules/`, and SvelteKit build outputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684250b386a88326a4f80db74e223ed4