### PR TITLE
Add run.py and PyInstaller spec

### DIFF
--- a/checklister.spec
+++ b/checklister.spec
@@ -1,0 +1,36 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(['run.py'],
+             pathex=[],
+             binaries=[],
+             datas=[('backend/twnamelist.db', 'backend')],
+             hiddenimports=[],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             win_no_prefer_redirects=False,
+             win_private_assemblies=False,
+             cipher=block_cipher,
+             noarchive=False)
+pyz = PYZ(a.pure, a.zipped_data,
+             cipher=block_cipher)
+exe = EXE(pyz,
+          a.scripts,
+          [],
+          exclude_binaries=True,
+          name='checklister',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          console=True)
+coll = COLLECT(exe,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               strip=False,
+               upx=True,
+               upx_exclude=[],
+               name='checklister')

--- a/run.py
+++ b/run.py
@@ -1,0 +1,17 @@
+import argparse
+import uvicorn
+
+from backend.main import app
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run the Checklister-NG backend")
+    parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind")
+    parser.add_argument("--port", type=int, default=8000, help="Port number to listen on")
+    args = parser.parse_args()
+
+    uvicorn.run(app, host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/spec/structure_doc.md
+++ b/spec/structure_doc.md
@@ -54,10 +54,30 @@
 2. **Frontend**  
    Inside `frontend`, install dependencies then start the dev server:
    ```bash
-   npm install
-   npm run dev
-   ```
-   The UI connects to the backend endpoints described above.
+    npm install
+    npm run dev
+    ```
+    The UI connects to the backend endpoints described above.
+
+### Packaging
+
+`run.py` boots the backend using Uvicorn and accepts optional `--host` and `--port` arguments.
+
+```bash
+python run.py --port 9000
+```
+
+Build a standalone executable with PyInstaller using the provided spec file:
+
+```bash
+pyinstaller -F checklister.spec
+```
+
+Run the resulting binary with the same options to change the listening port:
+
+```bash
+./dist/checklister --port 9000
+```
 
 ### Learning Pointers
 


### PR DESCRIPTION
## Summary
- add `run.py` for configurable Uvicorn startup
- provide `checklister.spec` so PyInstaller uses the new script
- document PyInstaller usage and how to pass a custom port

## Testing
- `python3 -m py_compile run.py backend/*.py backend/*/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684250e0674c83268b425cdeca05a317