### PR TITLE
Update PyInstaller command in docs

### DIFF
--- a/spec/structure_doc.md
+++ b/spec/structure_doc.md
@@ -67,10 +67,10 @@
 python run.py --port 9000
 ```
 
-Build a standalone executable with PyInstaller using the provided spec file:
+Build a standalone executable with PyInstaller using the provided spec file. The spec already defines the build mode:
 
 ```bash
-pyinstaller -F checklister.spec
+pyinstaller checklister.spec
 ```
 
 Run the resulting binary with the same options to change the listening port:


### PR DESCRIPTION
## Summary
- update PyInstaller command in `spec/structure_doc.md`
- explain that the spec file already controls the build mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684257e247bc832682bbce9acd188f3b