### PR TITLE
Update default port to 8964

### DIFF
--- a/run.py
+++ b/run.py
@@ -7,7 +7,7 @@ from backend.main import app
 def main():
     parser = argparse.ArgumentParser(description="Run the Checklister-NG backend")
     parser.add_argument("--host", default="127.0.0.1", help="Host interface to bind")
-    parser.add_argument("--port", type=int, default=8000, help="Port number to listen on")
+    parser.add_argument("--port", type=int, default=8964, help="Port number to listen on")
     args = parser.parse_args()
 
     uvicorn.run(app, host=args.host, port=args.port)

--- a/spec/structure_doc.md
+++ b/spec/structure_doc.md
@@ -64,7 +64,7 @@
 `run.py` boots the backend using Uvicorn and accepts optional `--host` and `--port` arguments.
 
 ```bash
-python run.py --port 9000
+python run.py --port 8964
 ```
 
 Build a standalone executable with PyInstaller using the provided spec file. The spec already defines the build mode:
@@ -78,7 +78,7 @@ binary in `dist/checklister`. Run the binary with the same options to change the
 listening port:
 
 ```bash
-./dist/checklister --port 9000
+./dist/checklister --port 8964
 ```
 
 ### Learning Pointers


### PR DESCRIPTION
## Summary
- use port 8964 by default in `run.py`
- update the packaging instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842534b7e4483269f996d9ca3e67d58